### PR TITLE
Refactoring: typing, comments-into-names changes.

### DIFF
--- a/common/changes/@hcengineering/network-backrpc/refactoring-back-rpc_2025-10-06-13-11.json
+++ b/common/changes/@hcengineering/network-backrpc/refactoring-back-rpc_2025-10-06-13-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@hcengineering/network-backrpc",
+      "comment": "typing refactoring",
+      "type": "none"
+    }
+  ],
+  "packageName": "@hcengineering/network-backrpc"
+}

--- a/common/changes/@hcengineering/network-client/refactoring-back-rpc_2025-10-06-13-11.json
+++ b/common/changes/@hcengineering/network-client/refactoring-back-rpc_2025-10-06-13-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@hcengineering/network-client",
+      "comment": "renamings",
+      "type": "none"
+    }
+  ],
+  "packageName": "@hcengineering/network-client"
+}

--- a/packages/backrpc/src/__test__/backrpc.spec.ts
+++ b/packages/backrpc/src/__test__/backrpc.spec.ts
@@ -976,9 +976,9 @@ describe('backrpc', () => {
     )
 
     // Test that request limit can be configured
-    expect(server.requestsLimit).toBe(25) // Default value
-    server.requestsLimit = 10 // Set custom limit
-    expect(server.requestsLimit).toBe(10)
+    expect(server.requestsLimitPerClient).toBe(25) // Default value
+    server.requestsLimitPerClient = 10 // Set custom limit
+    expect(server.requestsLimitPerClient).toBe(10)
 
     const client = new BackRPCClient(
       'client1' as ClientId,

--- a/packages/client/src/agent.ts
+++ b/packages/client/src/agent.ts
@@ -30,7 +30,7 @@ export class NetworkAgentServer implements BackRPCServerHandler<ClientUuid> {
     tickMgr: TickManager,
     readonly endpointHost: string, // An endpoint construction host, will be used to register
     host: string = '*', // A socket visibility
-    port: number = 3738 // If 0, port will be free random one.
+    port: number | 'random' = 3738
   ) {
     this.rpcServer = new BackRPCServer<ClientUuid>(this, tickMgr, host, port)
   }


### PR DESCRIPTION
This pull request refactors the request limit and client timeout logic in the `BackRPCServer` and related classes to clarify their per-client nature and improve configurability. It also updates the port handling to allow for random port assignment. The most important changes are grouped below:

### Per-client request limit and timeout refactoring

* Renamed `requestsLimit` to `requestsLimitPerClient` throughout the codebase to clarify that the request limit applies per client, and updated all relevant checks and tests. [[1]](diffhunk://#diff-642c1445d67b607360230886a0e80523b27c8b19bf39afcbd5ca989b13df8584L62-R70) [[2]](diffhunk://#diff-67417f0f1b85c82fb216647755ade7ffd3c1fe407e33cfd7a3ebc443383bc05bL979-R981) [[3]](diffhunk://#diff-642c1445d67b607360230886a0e80523b27c8b19bf39afcbd5ca989b13df8584L246-R246)
* Renamed `aliveTimeout` in `RPCClientInfo` to `perClientAliveTimeoutSeconds` for clearer semantics, and updated all references and logic to use the new name. [[1]](diffhunk://#diff-642c1445d67b607360230886a0e80523b27c8b19bf39afcbd5ca989b13df8584L43-R43) [[2]](diffhunk://#diff-642c1445d67b607360230886a0e80523b27c8b19bf39afcbd5ca989b13df8584L99-R100) [[3]](diffhunk://#diff-642c1445d67b607360230886a0e80523b27c8b19bf39afcbd5ca989b13df8584L203-R206)

### Port configuration improvements

* Changed the `port` parameter in `BackRPCServer` and `NetworkAgentServer` to accept either a number or `'random'`, allowing random port assignment when needed. Updated the server startup logic to bind to port 0 when `'random'` is specified. [[1]](diffhunk://#diff-642c1445d67b607360230886a0e80523b27c8b19bf39afcbd5ca989b13df8584L62-R70) [[2]](diffhunk://#diff-642c1445d67b607360230886a0e80523b27c8b19bf39afcbd5ca989b13df8584L159-R159) [[3]](diffhunk://#diff-e7c512d770b76511baeeb1250799716422fe56eb7608b48b43be52ad30994d64L33-R33)